### PR TITLE
Switched to (imo) better error handling

### DIFF
--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
@@ -41,7 +41,11 @@ class BarcodeScanPlugin(val activity: Activity): MethodCallHandler,
       if (resultCode == Activity.RESULT_OK) {
         val barcode = data?.getStringExtra("SCAN_RESULT")
         barcode?.let { this.result?.success(barcode) }
+      } else {
+        val errorCode = data?.getStringExtra("ERROR_CODE")
+        this.result?.error(errorCode, null, null)
       }
+      return true
     }
     return false
   }

--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScannerActivity.kt
@@ -26,7 +26,6 @@ import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.support.design.widget.Snackbar
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
 import android.view.Menu
@@ -38,32 +37,29 @@ import me.dm7.barcodescanner.zxing.ZXingScannerView
 class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
 
     lateinit var scannerView: me.dm7.barcodescanner.zxing.ZXingScannerView
-    //lateinit var pressLightSnackBar: Snackbar
 
     companion object {
         val REQUEST_TAKE_PHOTO_CAMERA_PERMISSION = 100
         val TOGGLE_FLASH = 200
 
     }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         title = ""
         scannerView = ZXingScannerView(this)
         scannerView.setAutoFocus(true)
         setContentView(scannerView)
-//        pressLightSnackBar = Snackbar.make(scannerView, "Press Screen To Turn Light On",
-//                                           Int.MAX_VALUE)
-//        pressLightSnackBar.show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         if (scannerView.flash) {
             val item = menu.add(0,
-                                TOGGLE_FLASH, 0, "Flash Off")
+                    TOGGLE_FLASH, 0, "Flash Off")
             item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
         } else {
             val item = menu.add(0,
-                                TOGGLE_FLASH, 0, "Flash On")
+                    TOGGLE_FLASH, 0, "Flash On")
             item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
         }
         return super.onCreateOptionsMenu(menu)
@@ -81,6 +77,7 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
     override fun onResume() {
         super.onResume()
         scannerView.setResultHandler(this)
+        // start camera immediately if permission is already given
         if (!requestCameraAccessIfNecessary()) {
             scannerView.startCamera()
         }
@@ -98,38 +95,38 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
         finish()
     }
 
+    fun finishWithError(errorCode: String) {
+        val intent = Intent()
+        intent.putExtra("ERROR_CODE", errorCode)
+        setResult(Activity.RESULT_CANCELED, intent)
+        finish()
+    }
+
     private fun requestCameraAccessIfNecessary(): Boolean {
         val array = arrayOf(Manifest.permission.CAMERA)
         if (ContextCompat
-            .checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
-            if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.CAMERA)) {
-                val snackbar = Snackbar.make(scannerView, "Grant access to the camera to enable barcode scanning.", Snackbar.LENGTH_INDEFINITE)
-                snackbar.setAction("OK") {
-                    ActivityCompat.requestPermissions(this,
-                                            array,
-                                                      REQUEST_TAKE_PHOTO_CAMERA_PERMISSION)
-                }
-                snackbar.show()
-            } else {
-                ActivityCompat.requestPermissions(this,
-                                                  array,
-                                                  REQUEST_TAKE_PHOTO_CAMERA_PERMISSION)
-            }
+                .checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+
+            ActivityCompat.requestPermissions(this, array,
+                    REQUEST_TAKE_PHOTO_CAMERA_PERMISSION)
             return true
         }
         return false
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>,
-                                            grantResults: IntArray) {
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>,grantResults: IntArray) {
         when (requestCode) {
             REQUEST_TAKE_PHOTO_CAMERA_PERMISSION -> {
                 if (PermissionUtil.verifyPermissions(grantResults)) {
                     scannerView.startCamera()
+                } else {
+                    finishWithError("PERMISSION_NOT_GRANTED")
                 }
             }
+            else -> {
+                super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+            }
         }
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:barcode_scan/barcode_scan.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() {
   runApp(new MyApp());
@@ -43,7 +44,21 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future scan() async {
-    String barcode = await BarcodeScanner.scan();
-    setState(() => this.barcode = barcode);
+    try {
+      String barcode = await BarcodeScanner.scan();
+      setState(() => this.barcode = barcode);
+    } on PlatformException catch (e) {
+      if (e.code == 'PERMISSION_NOT_GRANTED') {
+        setState(() {
+          this.barcode = 'The user did not grant the camera permission!';
+        });
+      } else {
+        setState(() => this.barcode = 'Unknown error: $e');
+      }
+    } on FormatException{
+      setState(() => this.barcode = 'null (User returned using the "back"-button before scanning anything. Result)');
+    } catch (e) {
+      setState(() => this.barcode = 'Unknown error: $e');
+    }
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,7 @@ class _MyAppState extends State<MyApp> {
       String barcode = await BarcodeScanner.scan();
       setState(() => this.barcode = barcode);
     } on PlatformException catch (e) {
-      if (e.code == 'PERMISSION_NOT_GRANTED') {
+      if (e.code == BarcodeScanner.CameraAccessDenied) {
         setState(() {
           this.barcode = 'The user did not grant the camera permission!';
         });

--- a/ios/Classes/BarcodeScanPlugin.m
+++ b/ios/Classes/BarcodeScanPlugin.m
@@ -32,7 +32,7 @@
     }
 }
 
-- (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithErrorCode:(NSString *)errorCode {
+- (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didFailWithErrorCode:(NSString *)errorCode {
     if (self.result){
         self.result([FlutterError errorWithCode:errorCode
                                         message:nil

--- a/ios/Classes/BarcodeScanPlugin.m
+++ b/ios/Classes/BarcodeScanPlugin.m
@@ -27,7 +27,11 @@
 }
 
 - (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithResult:(NSString *)result {
-    if (self.result) {
+    if (self.result && [result isEqualToString: @"PERMISSION_NOT_GRANTED"]){
+        self.result([FlutterError errorWithCode:@"PERMISSION_NOT_GRANTED"
+                                   message:nil
+                                   details:nil]);
+    } else if (self.result) {
         self.result(result);
     }
 }

--- a/ios/Classes/BarcodeScanPlugin.m
+++ b/ios/Classes/BarcodeScanPlugin.m
@@ -27,12 +27,16 @@
 }
 
 - (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithResult:(NSString *)result {
-    if (self.result && [result isEqualToString: @"PERMISSION_NOT_GRANTED"]){
-        self.result([FlutterError errorWithCode:@"PERMISSION_NOT_GRANTED"
-                                   message:nil
-                                   details:nil]);
-    } else if (self.result) {
+    if (self.result) {
         self.result(result);
+    }
+}
+
+- (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithErrorCode:(NSString *)errorCode {
+    if (self.result){
+        self.result([FlutterError errorWithCode:errorCode
+                                        message:nil
+                                        details:nil]);
     }
 }
 

--- a/ios/Classes/BarcodeScannerViewController.m
+++ b/ios/Classes/BarcodeScannerViewController.m
@@ -38,7 +38,7 @@
         if (success) {
             [self startScan];
         } else {
-          [self.delegate barcodeScannerViewController:self didScanBarcodeWithErrorCode:@"PERMISSION_NOT_GRANTED"];
+          [self.delegate barcodeScannerViewController:self didFailWithErrorCode:@"PERMISSION_NOT_GRANTED"];
           [self dismissViewControllerAnimated:NO completion:nil];
         }
     }];

--- a/ios/Classes/BarcodeScannerViewController.m
+++ b/ios/Classes/BarcodeScannerViewController.m
@@ -38,7 +38,7 @@
         if (success) {
             [self startScan];
         } else {
-          [self.delegate barcodeScannerViewController:self didScanBarcodeWithResult:@"PERMISSION_NOT_GRANTED"];
+          [self.delegate barcodeScannerViewController:self didScanBarcodeWithErrorCode:@"PERMISSION_NOT_GRANTED"];
           [self dismissViewControllerAnimated:NO completion:nil];
         }
     }];

--- a/ios/Classes/BarcodeScannerViewController.m
+++ b/ios/Classes/BarcodeScannerViewController.m
@@ -38,7 +38,8 @@
         if (success) {
             [self startScan];
         } else {
-            [self showNoCameraAccessAlert];
+          [self.delegate barcodeScannerViewController:self didScanBarcodeWithResult:@"PERMISSION_NOT_GRANTED"];
+          [self dismissViewControllerAnimated:NO completion:nil];
         }
     }];
 }
@@ -79,16 +80,6 @@
                                                                                   style:UIBarButtonItemStylePlain
                                                                                  target:self action:@selector(toggle)];
     }
-}
-
-- (void)showNoCameraAccessAlert {
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Camera access denied"
-                                                                             message:@"Camera access has been disabled for this application. To turn camera access back on, please go to the iOS settings application."
-                                                                      preferredStyle:UIAlertControllerStyleAlert];
-    [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [self dismissViewControllerAnimated:YES completion:nil];
-    }]];
-    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)toggle {

--- a/ios/Classes/BarcodeScannerViewControllerDelegate.h
+++ b/ios/Classes/BarcodeScannerViewControllerDelegate.h
@@ -9,6 +9,6 @@
 @protocol BarcodeScannerViewControllerDelegate <NSObject>
 
 - (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithResult:(NSString *)result;
-- (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithErrorCode:(NSString *)errorCode;
+- (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didFailWithErrorCode:(NSString *)errorCode;
 
 @end

--- a/ios/Classes/BarcodeScannerViewControllerDelegate.h
+++ b/ios/Classes/BarcodeScannerViewControllerDelegate.h
@@ -9,5 +9,6 @@
 @protocol BarcodeScannerViewControllerDelegate <NSObject>
 
 - (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithResult:(NSString *)result;
+- (void)barcodeScannerViewController:(BarcodeScannerViewController *)controller didScanBarcodeWithErrorCode:(NSString *)errorCode;
 
 @end

--- a/lib/barcode_scan.dart
+++ b/lib/barcode_scan.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 
 class BarcodeScanner {
+  static const CameraAccessDenied = 'PERMISSION_NOT_GRANTED';
   static const MethodChannel _channel =
       const MethodChannel('com.apptreesoftware.barcode_scan');
   static Future<String> scan() async => await _channel.invokeMethod('scan');


### PR DESCRIPTION
Hey,

I recently started using your project since the other BarcodeScannerProject doesn't seem to be maintained anymore and I am still waiting for a PR to be merged (https://github.com/BenSower/BarcodeScannerPlugin/tree/scanlineFix) ;-).

Still,

I removed the internal iOs error messages if the user does not grant the permission the necessary permissions. This way, a dev can not only properly catch (no pun intended, but you can now actually catch it as a Platform exception with error code 
'PERMISSION_NOT_GRANTED') when that happens, but also react in whatever way and language he or she wants. This also somewhat solves the problem of the customizable error texts, since you can now define whatever message you like.

For more info, take a look into the example. 

I am still not a fan of the "cancel" als well as the "flash-on/off" Button in terms of internationalization and would recommend to replace both with the appropriate icons. Also, I do like the Android implementation of Zxing, which displays a frame for the scanner, which allows for easier aiming and would love something similar in iOs. 
I did implement both those things for the other project and will try to implement this, too...If there will be some time in the near future...