### PR TITLE
Fix missing Kotlin dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-egroup 'com.apptreesoftware.barcodescan'
+group 'com.apptreesoftware.barcodescan'
 version '1.0-SNAPSHOT'
 
 buildscript {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-group 'com.apptreesoftware.barcodescan'
+egroup 'com.apptreesoftware.barcodescan'
 version '1.0-SNAPSHOT'
 
 buildscript {
@@ -11,6 +11,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.2-4'
     }
 }
 


### PR DESCRIPTION
When building for Android, I was getting this error when trying to use this plugin.

```Launching lib/main.dart on Android SDK built for x86 in debug mode...
Initializing gradle...                                       0.9s
Resolving dependencies...
* Error running Gradle:
Exit code 1 from: /Users/aivanovs/data/flutter_girl/android/gradlew app:properties:
Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.
java.lang.IllegalStateException: compileSdkVersion is not specified.

* Where:
Build file '/Users/aivanovs/.pub-cache/hosted/pub.dartlang.org/barcode_scan-0.0.3/android/build.gradle' line: 27

* What went wrong:
A problem occurred evaluating project ':barcode_scan'.
> Plugin with id 'kotlin-android' not found.```