### PR TITLE
Removed Activity dependency on registration

### DIFF
--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
@@ -9,14 +9,14 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-class BarcodeScanPlugin(val activity: Activity): MethodCallHandler,
+class BarcodeScanPlugin(val registrar: Registrar): MethodCallHandler,
     PluginRegistry.ActivityResultListener {
   var result : Result? = null
   companion object {
     @JvmStatic
     fun registerWith(registrar: Registrar): Unit {
       val channel = MethodChannel(registrar.messenger(), "com.apptreesoftware.barcode_scan")
-      val plugin = BarcodeScanPlugin(registrar.activity())
+      val plugin = BarcodeScanPlugin(registrar)
       channel.setMethodCallHandler(plugin)
       registrar.addActivityResultListener(plugin)
     }
@@ -32,8 +32,8 @@ class BarcodeScanPlugin(val activity: Activity): MethodCallHandler,
   }
 
   private fun showBarcodeView() {
-    val intent = Intent(activity, BarcodeScannerActivity::class.java)
-    activity.startActivityForResult(intent, 100)
+    val intent = Intent(registrar.activity(), BarcodeScannerActivity::class.java)
+    registrar.activity().startActivityForResult(intent, 100)
   }
 
   override fun onActivityResult(code: Int, resultCode: Int, data: Intent?): Boolean {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -31,7 +31,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.yourcompany.barcodescanexample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -51,5 +51,5 @@ flutter {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.2-4'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.2-4'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,10 +4,11 @@ buildscript {
         maven {
             url "https://maven.google.com"
         }
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.2-4'
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Sun Jun 03 10:20:57 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
There are special cases where the `Registrar` does not have an attached activity (e.g. launched the app in the background). Currently if this happens the plugin throws an exception in the `registerWith` method. I refactored the code to allow an empty activity and only require it when the scan function is called.