### PR TITLE
fix version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+environment:
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"
+
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 


### PR DESCRIPTION
credit goes to
  - https://github.com/flutter/flutter/issues/20700

issue is resolved by just setting a minimum environment version for the
plugin

Closes #36 on the original project https://github.com/apptreesoftware/flutter_barcode_reader/issues/36