### PR TITLE
[Fixes #47] Add Camera permission to library Android manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.yourcompany.barcodescan">
 
+  <uses-permission android:name="android.permission.CAMERA" />
+
   <application>
     <activity android:name="com.apptreesoftware.barcodescan.BarcodeScannerActivity" />
   </application>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.CAMERA" />
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide


### PR DESCRIPTION
Makes integration into host applications easier
Removed the camera permission from the example to demonstrate