### PR TITLE
Stop scanning when pressed the cancel button on iOS

### DIFF
--- a/ios/Classes/BarcodeScannerViewController.m
+++ b/ios/Classes/BarcodeScannerViewController.m
@@ -62,6 +62,7 @@
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    [self.scanner stopScanning];
     [super viewWillDisappear:animated];
     if ([self isFlashOn]) {
         [self toggleFlash:NO];


### PR DESCRIPTION
It fixes the error which stop scanning when pressed the cancel button on iOS. In current version, the camera opens with lag if you press the cancel button and then scan again.