### PR TITLE
Fixed plugin registration to enable use this plugin with Flutter feature add-to-app + engine pre-warn

### DIFF
--- a/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/barcodescan/BarcodeScanPlugin.kt
@@ -2,53 +2,56 @@ package com.apptreesoftware.barcodescan
 
 import android.app.Activity
 import android.content.Intent
+import android.util.Log
+import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-class BarcodeScanPlugin(val activity: Activity): MethodCallHandler,
-    PluginRegistry.ActivityResultListener {
-  var result : Result? = null
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar): Unit {
-      val channel = MethodChannel(registrar.messenger(), "com.apptreesoftware.barcode_scan")
-        if (registrar.activity() != null) {
-            val plugin = BarcodeScanPlugin(registrar.activity())
+class BarcodeScanPlugin(private val registrar: Registrar) : MethodCallHandler, PluginRegistry.ActivityResultListener {
+    var result: Result? = null
+
+    companion object {
+        @JvmStatic
+        fun registerWith(registrar: Registrar) {
+            val channel = MethodChannel(registrar.messenger(), "com.apptreesoftware.barcode_scan")
+            val plugin = BarcodeScanPlugin(registrar)
             channel.setMethodCallHandler(plugin)
             registrar.addActivityResultListener(plugin)
-      }
+        }
     }
-  }
 
-  override fun onMethodCall(call: MethodCall, result: Result): Unit {
-    if (call.method.equals("scan")) {
-      this.result = result
-      showBarcodeView()
-    } else {
-      result.notImplemented()
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        if (call.method == "scan") {
+            this.result = result
+            showBarcodeView()
+        } else {
+            result.notImplemented()
+        }
     }
-  }
 
-  private fun showBarcodeView() {
-    val intent = Intent(activity, BarcodeScannerActivity::class.java)
-    activity.startActivityForResult(intent, 100)
-  }
-
-  override fun onActivityResult(code: Int, resultCode: Int, data: Intent?): Boolean {
-    if (code == 100) {
-      if (resultCode == Activity.RESULT_OK) {
-        val barcode = data?.getStringExtra("SCAN_RESULT")
-        barcode?.let { this.result?.success(barcode) }
-      } else {
-        val errorCode = data?.getStringExtra("ERROR_CODE")
-        this.result?.error(errorCode, null, null)
-      }
-      return true
+    private fun showBarcodeView() {
+        if (registrar.activity() == null) {
+            Log.e("BarcodeScanPlugin", "plugin can't launch scan activity, because plugin is not attached to any activity.")
+            return
+        }
+        val intent = Intent(registrar.activity(), BarcodeScannerActivity::class.java)
+        registrar.activity().startActivityForResult(intent, 100)
     }
-    return false
-  }
+
+    override fun onActivityResult(code: Int, resultCode: Int, data: Intent?): Boolean {
+        if (code == 100) {
+            if (resultCode == Activity.RESULT_OK) {
+                val barcode = data?.getStringExtra("SCAN_RESULT")
+                barcode?.let { this.result?.success(barcode) }
+            } else {
+                val errorCode = data?.getStringExtra("ERROR_CODE")
+                this.result?.error(errorCode, null, null)
+            }
+            return true
+        }
+        return false
+    }
 }


### PR DESCRIPTION
When we used this plugin in Flutter as add-to-app module. We found that plugin registration crashes when try to pre-warn the engine in application startup.

So, this crash is caused by the call _registrar.activity()_ on method _registerWith_ . For fix we remove all call to activity() getter on plugin registration and call it only when Flutter side calls to "scan".

regards.