### PR TITLE
Fixed request camera permission flow to solve issue 173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.0.2 - 2020-04-14
+
+Bugfixes:
+- [Fixed the request camera permission flow on Android](https://github.com/mintware-de/flutter_barcode_reader/pull/186) - @devtronic
+
 ## v2.0.1 - 2020-02-19
 
 Bugfixes:

--- a/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScanPlugin.kt
+++ b/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScanPlugin.kt
@@ -1,8 +1,14 @@
 package de.mintware.barcode_scan
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.util.Log
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import de.mintware.barcode_scan.BarcodeScannerActivity.Companion.REQUEST_CAMERA_PERMISSION
+import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -10,16 +16,24 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-class BarcodeScanPlugin(private val registrar: Registrar) : MethodCallHandler, PluginRegistry.ActivityResultListener {
+class BarcodeScanPlugin(private val registrar: Registrar) :
+        MethodCallHandler,
+        PluginRegistry.ActivityResultListener,
+        PluginRegistry.RequestPermissionsResultListener,
+        EventChannel.StreamHandler {
     var result: Result? = null
+    var sink: EventChannel.EventSink? = null;
 
     companion object {
         @JvmStatic
         fun registerWith(registrar: Registrar) {
             val channel = MethodChannel(registrar.messenger(), "de.mintware.barcode_scan")
+            val eventChannel = EventChannel(registrar.messenger(), "de.mintware.barcode_scan/events")
             val plugin = BarcodeScanPlugin(registrar)
+            eventChannel.setStreamHandler(plugin);
             channel.setMethodCallHandler(plugin)
             registrar.addActivityResultListener(plugin)
+            registrar.addRequestPermissionsResultListener(plugin)
         }
     }
 
@@ -27,6 +41,8 @@ class BarcodeScanPlugin(private val registrar: Registrar) : MethodCallHandler, P
         if (call.method == "scan") {
             this.result = result
             showBarcodeView()
+        } else if (call.method == "request_permission") {
+            result.success(requestCameraAccessIfNecessary())
         } else {
             result.notImplemented()
         }
@@ -53,5 +69,67 @@ class BarcodeScanPlugin(private val registrar: Registrar) : MethodCallHandler, P
             return true
         }
         return false
+    }
+
+    private fun requestCameraAccessIfNecessary(): Boolean {
+        val array = arrayOf(Manifest.permission.CAMERA)
+        if (ContextCompat.checkSelfPermission(registrar.activity(), Manifest.permission.CAMERA)
+                == PackageManager.PERMISSION_GRANTED) {
+            return false
+        }
+
+        ActivityCompat.requestPermissions(registrar.activity(), array, REQUEST_CAMERA_PERMISSION)
+        return true
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int,
+                                            permissions: Array<out String>?,
+                                            grantResults: IntArray?
+    ): Boolean {
+        if (requestCode != REQUEST_CAMERA_PERMISSION) {
+            return false;
+        }
+
+        if (PermissionUtil.verifyPermissions(grantResults)) {
+            sink?.success("PERMISSION_GRANTED");
+        } else {
+            sink?.success("PERMISSION_NOT_GRANTED");
+        }
+        return true;
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        sink = events;
+    }
+
+    override fun onCancel(arguments: Any?) {
+        sink = null;
+    }
+}
+
+object PermissionUtil {
+
+    /**
+     * Check that all given permissions have been granted by verifying that each entry in the
+     * given array is of the value [PackageManager.PERMISSION_GRANTED].
+
+     * @see Activity.onRequestPermissionsResult
+     */
+    fun verifyPermissions(grantResults: IntArray?): Boolean {
+        if (grantResults == null) {
+            return false;
+        }
+        // At least one result must be checked.
+        if (grantResults.size < 1) {
+            return false
+        }
+
+        // Verify that each required permission has been granted, otherwise return false.
+        for (result in grantResults) {
+            if (result != PackageManager.PERMISSION_GRANTED) {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScannerActivity.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import com.google.zxing.Result
 import me.dm7.barcodescanner.zxing.ZXingScannerView
 
-
 class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
 
     lateinit var scannerView: ZXingScannerView
@@ -30,7 +29,7 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        val buttonText = if (it.flash) "Flash Off" else "Flash On"
+        val buttonText = if (scannerView.flash) "Flash Off" else "Flash On"
         val item = menu.add(0, TOGGLE_FLASH, 0, buttonText)
         item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
         return super.onCreateOptionsMenu(menu)
@@ -59,14 +58,7 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
     override fun handleResult(result: Result?) {
         val intent = Intent()
         intent.putExtra("SCAN_RESULT", result.toString())
-        setResult(Activity.RESULT_OK, intent)
-        finish()
-    }
-
-    fun finishWithError(errorCode: String) {
-        val intent = Intent()
-        intent.putExtra("ERROR_CODE", errorCode)
-        setResult(Activity.RESULT_CANCELED, intent)
+        setResult(RESULT_OK, intent)
         finish()
     }
 }

--- a/ios/Classes/BarcodeScanPlugin.m
+++ b/ios/Classes/BarcodeScanPlugin.m
@@ -14,6 +14,8 @@
     if ([@"scan" isEqualToString:call.method]) {
         self.result = result;
         [self showBarcodeView];
+    } else if ([@"request_permission" isEqualToString:call.method]) {
+        result(@(NO));
     } else {
         result(FlutterMethodNotImplemented);
     }

--- a/lib/barcode_scan.dart
+++ b/lib/barcode_scan.dart
@@ -5,6 +5,9 @@ import 'package:flutter/services.dart';
 /// Barcode scanner plugin
 /// Simply call `var barcode = await BarcodeScanner.scan()` to scan a barcode
 class BarcodeScanner {
+  /// If the user has granted the access to the camera this code is returned.
+  static const CameraAccessGranted = 'PERMISSION_GRANTED';
+
   /// If the user has not granted the access to the camera this code is thrown.
   static const CameraAccessDenied = 'PERMISSION_NOT_GRANTED';
 
@@ -15,9 +18,39 @@ class BarcodeScanner {
   static const MethodChannel _channel =
       const MethodChannel('de.mintware.barcode_scan');
 
+  /// The event channel
+  static const EventChannel _eventChannel =
+      const EventChannel('de.mintware.barcode_scan/events');
+
   /// Starts the camera for scanning the barcode, shows a preview window and
   /// returns the barcode if one was scanned.
   /// Can throw an exception.
   /// See also [CameraAccessDenied] and [UserCanceled]
-  static Future<String> scan() async => await _channel.invokeMethod('scan');
+  static Future<String> scan() async {
+    var events = _eventChannel.receiveBroadcastStream();
+    var permissionsRequested =
+        await _channel.invokeMethod('request_permission');
+    if (permissionsRequested) {
+      var completer = Completer<String>();
+
+      StreamSubscription subscription;
+      subscription = events.listen((event) async {
+        if (event is String) {
+          if (event == CameraAccessGranted) {
+            subscription.cancel();
+            completer.complete(await _channel.invokeMethod('scan'));
+          } else if (event == CameraAccessDenied) {
+            subscription.cancel();
+            completer.completeError(
+              PlatformException(code: CameraAccessDenied),
+            );
+          }
+        }
+      });
+
+      return completer.future;
+    } else {
+      return await _channel.invokeMethod('scan');
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: barcode_scan
 description: A flutter plugin for scanning 2D barcodes and QRCodes via camera.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/mintware-de/flutter_barcode_reader
 
 dependencies:


### PR DESCRIPTION
Fixes the "request for camera permission" flow which previously caused an app crash which is described in #173 .

Cause:
The scanner view was created before the permission was requested.

Fix:
Create the scanner view after the permission was granted

Test:
```yaml
# pubspec.yaml
dependencies:
  barcode_scan:
    git:
      url: https://github.com/mintware-de/flutter_barcode_reader.git
      ref: fix_173
```